### PR TITLE
[SPARK-37981][PYTHON] Add note for deleting Null and NaN

### DIFF
--- a/python/pyspark/pandas/generic.py
+++ b/python/pyspark/pandas/generic.py
@@ -904,6 +904,8 @@ class Frame(object, metaclass=ABCMeta):
 
         .. note:: output JSON format is different from pandas'. It always use `orient='records'`
             for its output. This behaviour might have to change in the near future.
+        
+        .. note:: If column have only NaN or Null values. The column well be deleted.
 
         Note NaN's and None will be converted to null and datetime objects
         will be converted to UNIX timestamps.


### PR DESCRIPTION
### What changes were proposed in this pull request?

This is for SPARK-37981 Deletes columns with all Null as default.
Do also see https://github.com/apache/spark/pull/26098
User @HyukjinKwon did a reviewed on 21 Oct 2019 
"Hey, you should document this in DataFrameWrtier, DataStreamWrtier, readwriter.py"

This PR are for Koalas, pandas on spark and pandas on spark API.  

### Why are the changes needed?
Users need to know why there column(s) with all NaN or Null are gone.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
No.
